### PR TITLE
Respelled "description"; added missing colon.

### DIFF
--- a/source/pluginexamples/commands.rst
+++ b/source/pluginexamples/commands.rst
@@ -13,7 +13,7 @@ Commands
       description: "Example1 command"
       usage: "/example1"
      example2:
-      descroption "Example2 command with arguments"
+      description: "Example2 command with arguments"
       usage: "/example2 <args>"
 
 


### PR DESCRIPTION
In the commands > example2 section, the word "description" was spelt "descroption" and there was no colon after it.
